### PR TITLE
Remove Social Accounts, Contact, Leads regions from lightning pages and remove the New Contact quick action as it is not required for b2c-crm-sync to work

### DIFF
--- a/src/sfdc/base/main/default/flexipages/Account_Record_Page.flexipage-meta.xml
+++ b/src/sfdc/base/main/default/flexipages/Account_Record_Page.flexipage-meta.xml
@@ -74,16 +74,6 @@
     <flexiPageRegions>
         <itemInstances>
             <componentInstance>
-                <componentName>runtime_sales_social:socialPanel</componentName>
-            </componentInstance>
-        </itemInstances>
-        <mode>Replace</mode>
-        <name>newsTabContent</name>
-        <type>Facet</type>
-    </flexiPageRegions>
-    <flexiPageRegions>
-        <itemInstances>
-            <componentInstance>
                 <componentInstanceProperties>
                     <name>active</name>
                     <value>true</value>

--- a/src/sfdc/base/main/default/flexipages/B2C_Account_Record_Page.flexipage-meta.xml
+++ b/src/sfdc/base/main/default/flexipages/B2C_Account_Record_Page.flexipage-meta.xml
@@ -106,16 +106,6 @@
     <flexiPageRegions>
         <itemInstances>
             <componentInstance>
-                <componentName>runtime_sales_social:socialPanel</componentName>
-            </componentInstance>
-        </itemInstances>
-        <mode>Replace</mode>
-        <name>newsTabContent</name>
-        <type>Facet</type>
-    </flexiPageRegions>
-    <flexiPageRegions>
-        <itemInstances>
-            <componentInstance>
                 <componentInstanceProperties>
                     <name>active</name>
                     <value>true</value>

--- a/src/sfdc/base/main/default/layouts/Account-B2C%3A Account%28Support%29 Layout.layout-meta.xml
+++ b/src/sfdc/base/main/default/layouts/Account-B2C%3A Account%28Support%29 Layout.layout-meta.xml
@@ -165,9 +165,6 @@
     </layoutSections>
     <quickActionList>
         <quickActionListItems>
-            <quickActionName>NewContact</quickActionName>
-        </quickActionListItems>
-        <quickActionListItems>
             <quickActionName>FeedItem.TextPost</quickActionName>
         </quickActionListItems>
         <quickActionListItems>
@@ -183,13 +180,6 @@
             <quickActionName>FeedItem.QuestionPost</quickActionName>
         </quickActionListItems>
     </quickActionList>
-    <relatedContent>
-        <relatedContentItems>
-            <layoutItem>
-                <component>runtime_sales_social:socialPanel</component>
-            </layoutItem>
-        </relatedContentItems>
-    </relatedContent>
     <relatedLists>
         <excludeButtons>MassAddToCampaign</excludeButtons>
         <fields>FULL_NAME</fields>

--- a/src/sfdc/base/main/default/layouts/Contact-B2C%3A Contact %28Support%29 Layout.layout-meta.xml
+++ b/src/sfdc/base/main/default/layouts/Contact-B2C%3A Contact %28Support%29 Layout.layout-meta.xml
@@ -347,11 +347,6 @@
                 <field>AccountId</field>
             </layoutItem>
         </relatedContentItems>
-        <relatedContentItems>
-            <layoutItem>
-                <component>runtime_sales_social:socialPanel</component>
-            </layoutItem>
-        </relatedContentItems>
     </relatedContent>
     <relatedLists>
         <excludeButtons>MassChangeOwner</excludeButtons>

--- a/src/sfdc/extras/sf-connect/base/main/default/layouts/Contact-B2C%3A Contact %28Support%29 Layout.layout-meta.xml
+++ b/src/sfdc/extras/sf-connect/base/main/default/layouts/Contact-B2C%3A Contact %28Support%29 Layout.layout-meta.xml
@@ -359,11 +359,6 @@
                 <field>AccountId</field>
             </layoutItem>
         </relatedContentItems>
-        <relatedContentItems>
-            <layoutItem>
-                <component>runtime_sales_social:socialPanel</component>
-            </layoutItem>
-        </relatedContentItems>
     </relatedContent>
     <relatedLists>
         <excludeButtons>New</excludeButtons>

--- a/src/sfdc/personaccounts/main/default/layouts/PersonAccount-B2C%3A Person Account %28Support%29 Layout.layout-meta.xml
+++ b/src/sfdc/personaccounts/main/default/layouts/PersonAccount-B2C%3A Person Account %28Support%29 Layout.layout-meta.xml
@@ -345,13 +345,6 @@
             <quickActionName>FeedItem.ContentPost</quickActionName>
         </quickActionListItems>
     </quickActionList>
-    <relatedContent>
-        <relatedContentItems>
-            <layoutItem>
-                <component>runtime_sales_social:socialPanel</component>
-            </layoutItem>
-        </relatedContentItems>
-    </relatedContent>
     <relatedLists>
         <excludeButtons>MassChangeOwner</excludeButtons>
         <excludeButtons>New</excludeButtons>


### PR DESCRIPTION
Fix #14 and #6