### PR TITLE
fixes issue with sfcc-ci 2.9.0 being broken

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "b2c-crm-sync",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "b2c-crm-sync",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Enablement solution teaching the Salesforce Architect Success B2C Customer Data Strategy.  Unlock frictionless customer experiences by leveraging b2c-crm-sync's progressive resolution of B2C Customer Profiles between B2C Commerce and the Salesforce Platform.",
   "main": "cli.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "ora": "^5.4.0",
     "recursive-readdir": "^2.2.2",
     "save": "^2.4.0",
-    "sfcc-ci": "^2.7.2",
+    "sfcc-ci": "~2.7.2",
     "sfdx-node": "^3.1.0",
     "terminal-link": "^2.1.1",
     "validate.js": "^0.13.1",


### PR DESCRIPTION
sfcc-ci 2.9.0 is broken due to a dependency issue; carat ^ resolution here will upgrade to that version when using npm install; changing to tilde ~ will keep it in the range this has been tested with (and is locked in package-lock.json)

Another possible fix is to recommend `npm ci` instead of `npm install` in the instructions to use the locked versions.

Upstream issue https://github.com/SalesforceCommerceCloud/sfcc-ci/issues/280