### PR TITLE
fixes issue with sfcc-ci 2.9.0 being broken

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "ora": "^5.4.0",
     "recursive-readdir": "^2.2.2",
     "save": "^2.4.0",
-    "sfcc-ci": "^2.7.2",
+    "sfcc-ci": "~2.7.2",
     "sfdx-node": "^3.1.0",
     "terminal-link": "^2.1.1",
     "validate.js": "^0.13.1",


### PR DESCRIPTION
sfcc-ci 2.9.0 is broken due to a dependency issue; carat ^ resolution
here will upgrade to that version when using npm install; changing to
tilde ~ will keep it in the range this has been tested with (and is
locked in package-lock.json)