### PR TITLE
wrap password in cdata to avoid XML encoding errors

### DIFF
--- a/src/sfdc/_templates/namedCredentials/template_B2C_OOBO.namedCredential-meta.xml
+++ b/src/sfdc/_templates/namedCredentials/template_B2C_OOBO.namedCredential-meta.xml
@@ -8,5 +8,5 @@
     <principalType>PerUser</principalType>
     <protocol>Password</protocol>
     <username>{{B2C_USERNAME}}</username>
-    <password>{{B2C_ACCESSKEY}}:{{B2C_CLIENTSECRET}}</password>
+    <password><![CDATA[{{B2C_ACCESSKEY}}:{{B2C_CLIENTSECRET}}]]></password>
 </NamedCredential>


### PR DESCRIPTION
It's not uncommon for the client secret to contain invalid XML chars (for instance '&' or '<'). This results in an ugly error and failed deploy. 

CDATA in this element ensures the interpolated values are treated as character data and not XML.