### PR TITLE
Upsert Map instead of List for Account update

### DIFF
--- a/src/sfdc/base/main/default/classes/B2CIAProcessCustomerProfile.cls
+++ b/src/sfdc/base/main/default/classes/B2CIAProcessCustomerProfile.cls
@@ -108,7 +108,12 @@ public with sharing class B2CIAProcessCustomerProfile extends B2CBaseAttributeAs
             customerProfiles.size() > 0) {
 
             // If so, then process the customerProfiles
-            upsert customerProfiles;
+            
+            Map<id,SObject> accmap = new Map<id,SObject>();   
+                
+            accmap.putall(customerProfiles);
+                
+            upsert accmap.values();
 
         }
 


### PR DESCRIPTION
Upserting a Map instead to prevent duplicate sObject IDs in List

https://help.salesforce.com/s/articleView?id=000316303&type=1