### PR TITLE
Modify the Account Manager Auth Token token type from UUID to JWT

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ profile
 ```
 
 - Token Endpoint Auth Method: `private_key_jwt`
-- Access Token Format: `UUID`
+- Access Token Format: `JWT`
 
 7. Click the `Save` button to apply these changes to your ClientID's configuration.
 

--- a/src/sfdc/base/main/default/classes/B2CActiveCustomerPromotions_Test.cls
+++ b/src/sfdc/base/main/default/classes/B2CActiveCustomerPromotions_Test.cls
@@ -14,7 +14,7 @@ public with sharing class B2CActiveCustomerPromotions_Test {
             'Audit_Authentication_API_Interactions__c' => true
         });
         B2C_AuthToken__c authToken = (B2C_AuthToken__c)TestDataFactory.createSObject('B2C_AuthToken__c', new Map<String,Object>{
-            'Name' => 'my-test-authtoken',
+            'B2C_AuthToken__c' => 'my-test-authtoken',
             'B2C_Client_ID__c' => clientId.Id
         });
         B2C_CustomerList__c customerList = (B2C_CustomerList__c)TestDataFactory.createSObject('B2C_CustomerList__c', new Map<String,Object>{

--- a/src/sfdc/base/main/default/classes/B2CCustomerAddressBook_Test.cls
+++ b/src/sfdc/base/main/default/classes/B2CCustomerAddressBook_Test.cls
@@ -13,7 +13,7 @@ public with sharing class B2CCustomerAddressBook_Test {
             'Audit_Authentication_API_Interactions__c' => true
         });
         B2C_AuthToken__c authToken = (B2C_AuthToken__c)TestDataFactory.createSObject('B2C_AuthToken__c', new Map<String,Object>{
-            'Name' => 'my-test-authtoken',
+            'B2C_AuthToken__c' => 'my-test-authtoken',
             'B2C_Client_ID__c' => clientId.Id
         });
         B2C_CustomerList__c customerList = (B2C_CustomerList__c)TestDataFactory.createSObject('B2C_CustomerList__c', new Map<String,Object>{

--- a/src/sfdc/base/main/default/classes/B2CIAPersistB2CAuthToken.cls
+++ b/src/sfdc/base/main/default/classes/B2CIAPersistB2CAuthToken.cls
@@ -55,7 +55,7 @@ public with sharing class B2CIAPersistB2CAuthToken {
                     // If so, create an instance of the authToken
                     authToken = new B2C_AuthToken__c(
                         B2C_Client_ID__c = thisAuthTokenResult.b2cClientIdRecordId,
-                        Name = thisAuthTokenResult.accessToken
+                        B2C_AuthToken__c = thisAuthTokenResult.accessToken
                     );
 
                     // Create the collection of authTokens to process
@@ -98,7 +98,7 @@ public with sharing class B2CIAPersistB2CAuthToken {
 
             // Create the authTokenId map / Id quickReference
             for (B2C_AuthToken__c thisAuthToken : authTokens) {
-                authTokenIds.put(thisAuthToken.Name, thisAuthToken.Id);
+                authTokenIds.put(thisAuthToken.B2C_AuthToken__c, thisAuthToken.Id);
             }
 
         }

--- a/src/sfdc/base/main/default/classes/B2CIAPersistB2CAuthToken_Test.cls
+++ b/src/sfdc/base/main/default/classes/B2CIAPersistB2CAuthToken_Test.cls
@@ -71,8 +71,7 @@ private class B2CIAPersistB2CAuthToken_Test {
         List<B2C_AuthToken__c> testAuthToken = [
             SELECT  Id
             FROM    B2C_AuthToken__c
-            WHERE   Name = :authTokenResult.accessToken
-            AND     B2C_Client_ID__c = :authTokenResult.b2cClientIdRecordId
+            WHERE   B2C_Client_ID__c = :authTokenResult.b2cClientIdRecordId
             LIMIT   1
         ];
 
@@ -153,8 +152,7 @@ private class B2CIAPersistB2CAuthToken_Test {
         List<B2C_AuthToken__c> testAuthToken = [
                 SELECT  Id
                 FROM    B2C_AuthToken__c
-                WHERE   Name = :authTokenResult.accessToken
-                AND     B2C_Client_ID__c = :authTokenResult.b2cClientIdRecordId
+                WHERE   B2C_Client_ID__c = :authTokenResult.b2cClientIdRecordId
                 LIMIT   1
         ];
 
@@ -235,8 +233,7 @@ private class B2CIAPersistB2CAuthToken_Test {
         List<B2C_AuthToken__c> testAuthToken = [
             SELECT  Id
             FROM    B2C_AuthToken__c
-            WHERE   Name = :authTokenResult.accessToken
-            AND     B2C_Client_ID__c = :authTokenResult.b2cClientIdRecordId
+            WHERE   B2C_Client_ID__c = :authTokenResult.b2cClientIdRecordId
             LIMIT   1
         ];
 
@@ -244,8 +241,7 @@ private class B2CIAPersistB2CAuthToken_Test {
         List<B2C_Client_ID_Integration_History__c> testIntegrationHistory = [
             SELECT  Id
             FROM    B2C_Client_ID_Integration_History__c
-            WHERE   Auth_Token_Value__c = :authTokenResult.accessToken
-            AND     B2C_Client_ID__c = :authTokenResult.b2cClientIdRecordId
+            WHERE   B2C_Client_ID__c = :authTokenResult.b2cClientIdRecordId
         ];
 
         // Validate that the authToken and integration history were not persisted

--- a/src/sfdc/base/main/default/flexipages/B2C_AuthToken_Record_Page.flexipage-meta.xml
+++ b/src/sfdc/base/main/default/flexipages/B2C_AuthToken_Record_Page.flexipage-meta.xml
@@ -37,8 +37,8 @@
                     <name>numVisibleActions</name>
                     <value>3</value>
                 </componentInstanceProperties>
-                <identifier>highlightsPanel1Id</identifier>
                 <componentName>force:highlightsPanel</componentName>
+                <identifier>highlightsPanel1Id</identifier>
             </componentInstance>
         </itemInstances>
         <mode>Replace</mode>
@@ -52,8 +52,8 @@
                     <name>hideHeader</name>
                     <value>false</value>
                 </componentInstanceProperties>
-                <identifier>relatedListQuickLinksContainer1Id</identifier>
                 <componentName>force:relatedListQuickLinksContainer</componentName>
+                <identifier>relatedListQuickLinksContainer1Id</identifier>
             </componentInstance>
         </itemInstances>
         <name>Facet-74d97c91-4615-4456-ae46-9210eeef6c80</name>
@@ -62,14 +62,22 @@
     <flexiPageRegions>
         <itemInstances>
             <fieldInstance>
-                <identifier>name1Id</identifier>
-                <fieldItem>Record.Name</fieldItem>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.B2C_Client_ID__c</fieldItem>
+                <identifier>b2cClientId1Id</identifier>
             </fieldInstance>
         </itemInstances>
         <itemInstances>
             <fieldInstance>
-                <identifier>b2cClientId1Id</identifier>
-                <fieldItem>Record.B2C_Client_ID__c</fieldItem>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.B2C_AuthToken__c</fieldItem>
+                <identifier>RecordB2C_AuthToken_cField</identifier>
             </fieldInstance>
         </itemInstances>
         <name>Facet-3267fb33-4cb0-471f-b73c-c493b7e38c96</name>
@@ -78,8 +86,12 @@
     <flexiPageRegions>
         <itemInstances>
             <fieldInstance>
-                <identifier>isValid1Id</identifier>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
                 <fieldItem>Record.Is_Valid__c</fieldItem>
+                <identifier>isValid1Id</identifier>
                 <visibilityRule>
                     <criteria>
                         <leftValue>{!Record.Name}</leftValue>
@@ -90,8 +102,12 @@
         </itemInstances>
         <itemInstances>
             <fieldInstance>
-                <identifier>isExpired1Id</identifier>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
                 <fieldItem>Record.Is_Expired__c</fieldItem>
+                <identifier>isExpired1Id</identifier>
                 <visibilityRule>
                     <criteria>
                         <leftValue>{!Record.Name}</leftValue>
@@ -106,8 +122,8 @@
                     <name>uiBehavior</name>
                     <value>readonly</value>
                 </fieldInstanceProperties>
-                <identifier>expirationDate1Id</identifier>
                 <fieldItem>Record.Expiration_Date__c</fieldItem>
+                <identifier>expirationDate1Id</identifier>
                 <visibilityRule>
                     <criteria>
                         <leftValue>{!Record.Name}</leftValue>
@@ -126,8 +142,8 @@
                     <name>body</name>
                     <value>Facet-3267fb33-4cb0-471f-b73c-c493b7e38c96</value>
                 </componentInstanceProperties>
-                <identifier>column1Id</identifier>
                 <componentName>flexipage:column</componentName>
+                <identifier>column1Id</identifier>
             </componentInstance>
         </itemInstances>
         <itemInstances>
@@ -136,8 +152,8 @@
                     <name>body</name>
                     <value>Facet-314b7e2a-7dfe-4400-865c-3480757a4e93</value>
                 </componentInstanceProperties>
-                <identifier>column2Id</identifier>
                 <componentName>flexipage:column</componentName>
+                <identifier>column2Id</identifier>
             </componentInstance>
         </itemInstances>
         <name>Facet-f708e4ba-89cd-4fc2-987b-fb15c334312b</name>
@@ -146,8 +162,12 @@
     <flexiPageRegions>
         <itemInstances>
             <fieldInstance>
-                <identifier>isInvalidated1Id</identifier>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
                 <fieldItem>Record.Is_Invalidated__c</fieldItem>
+                <identifier>isInvalidated1Id</identifier>
                 <visibilityRule>
                     <criteria>
                         <leftValue>{!Record.Name}</leftValue>
@@ -162,8 +182,12 @@
     <flexiPageRegions>
         <itemInstances>
             <fieldInstance>
-                <identifier>invalidationDate1Id</identifier>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
                 <fieldItem>Record.Invalidation_Date__c</fieldItem>
+                <identifier>invalidationDate1Id</identifier>
                 <visibilityRule>
                     <criteria>
                         <leftValue>{!Record.Name}</leftValue>
@@ -182,8 +206,8 @@
                     <name>body</name>
                     <value>Facet-f1477d29-8a04-426d-b793-e893e73c2bfc</value>
                 </componentInstanceProperties>
-                <identifier>column3Id</identifier>
                 <componentName>flexipage:column</componentName>
+                <identifier>column3Id</identifier>
             </componentInstance>
         </itemInstances>
         <itemInstances>
@@ -192,8 +216,8 @@
                     <name>body</name>
                     <value>Facet-c52df0f4-a5eb-4815-bc19-61d10f8ebb04</value>
                 </componentInstanceProperties>
-                <identifier>column4Id</identifier>
                 <componentName>flexipage:column</componentName>
+                <identifier>column4Id</identifier>
             </componentInstance>
         </itemInstances>
         <name>Facet-c87c23ea-920b-4c2f-99d7-e847c6c540d8</name>
@@ -202,14 +226,22 @@
     <flexiPageRegions>
         <itemInstances>
             <fieldInstance>
-                <identifier>b2cClientIdValue1Id</identifier>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
                 <fieldItem>Record.B2C_ClientID_Value__c</fieldItem>
+                <identifier>b2cClientIdValue1Id</identifier>
             </fieldInstance>
         </itemInstances>
         <itemInstances>
             <fieldInstance>
-                <identifier>b2cClientIdActive1Id</identifier>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
                 <fieldItem>Record.Is_B2C_Client_ID_Active__c</fieldItem>
+                <identifier>b2cClientIdActive1Id</identifier>
             </fieldInstance>
         </itemInstances>
         <name>Facet-cd6118d4-425b-4e58-bb10-a82ce1134b1b</name>
@@ -218,14 +250,22 @@
     <flexiPageRegions>
         <itemInstances>
             <fieldInstance>
-                <identifier>jwtCertificateDevName1Id</identifier>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
                 <fieldItem>Record.JWT_Certificate_Developer_Name__c</fieldItem>
+                <identifier>jwtCertificateDevName1Id</identifier>
             </fieldInstance>
         </itemInstances>
         <itemInstances>
             <fieldInstance>
-                <identifier>jwtCertificateValid1Id</identifier>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
                 <fieldItem>Record.Is_JWT_Certificate_Valid__c</fieldItem>
+                <identifier>jwtCertificateValid1Id</identifier>
             </fieldInstance>
         </itemInstances>
         <name>Facet-4825fcdc-bf36-41a6-bf45-e11af9e7f084</name>
@@ -238,8 +278,8 @@
                     <name>body</name>
                     <value>Facet-cd6118d4-425b-4e58-bb10-a82ce1134b1b</value>
                 </componentInstanceProperties>
-                <identifier>column5Id</identifier>
                 <componentName>flexipage:column</componentName>
+                <identifier>column5Id</identifier>
             </componentInstance>
         </itemInstances>
         <itemInstances>
@@ -248,8 +288,8 @@
                     <name>body</name>
                     <value>Facet-4825fcdc-bf36-41a6-bf45-e11af9e7f084</value>
                 </componentInstanceProperties>
-                <identifier>column6Id</identifier>
                 <componentName>flexipage:column</componentName>
+                <identifier>column6Id</identifier>
             </componentInstance>
         </itemInstances>
         <name>Facet-af471c55-e9ac-4890-a5c0-1b1953905f34</name>
@@ -258,8 +298,12 @@
     <flexiPageRegions>
         <itemInstances>
             <fieldInstance>
-                <identifier>description1Id</identifier>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
                 <fieldItem>Record.Description__c</fieldItem>
+                <identifier>description1Id</identifier>
             </fieldInstance>
         </itemInstances>
         <name>Facet-d99332d0-6cb3-4fd6-afab-fc4b429e21e6</name>
@@ -272,8 +316,8 @@
                     <name>body</name>
                     <value>Facet-d99332d0-6cb3-4fd6-afab-fc4b429e21e6</value>
                 </componentInstanceProperties>
-                <identifier>column7Id</identifier>
                 <componentName>flexipage:column</componentName>
+                <identifier>column7Id</identifier>
             </componentInstance>
         </itemInstances>
         <name>Facet-2e08eb45-6910-4538-b3e2-15c1b0548d9d</name>
@@ -290,8 +334,8 @@
                     <name>label</name>
                     <value>Status</value>
                 </componentInstanceProperties>
-                <identifier>fieldSection1Id</identifier>
                 <componentName>flexipage:fieldSection</componentName>
+                <identifier>fieldSection1Id</identifier>
             </componentInstance>
         </itemInstances>
         <itemInstances>
@@ -304,8 +348,8 @@
                     <name>label</name>
                     <value>Manually Invalidate B2C AuthToken</value>
                 </componentInstanceProperties>
-                <identifier>fieldSection2Id</identifier>
                 <componentName>flexipage:fieldSection</componentName>
+                <identifier>fieldSection2Id</identifier>
                 <visibilityRule>
                     <criteria>
                         <leftValue>{!Record.Name}</leftValue>
@@ -324,8 +368,8 @@
                     <name>label</name>
                     <value>B2C Client ID Properties</value>
                 </componentInstanceProperties>
-                <identifier>fieldSection3Id</identifier>
                 <componentName>flexipage:fieldSection</componentName>
+                <identifier>fieldSection3Id</identifier>
                 <visibilityRule>
                     <criteria>
                         <leftValue>{!Record.Name}</leftValue>
@@ -344,8 +388,8 @@
                     <name>label</name>
                     <value>Description</value>
                 </componentInstanceProperties>
-                <identifier>fieldSection4Id</identifier>
                 <componentName>flexipage:fieldSection</componentName>
+                <identifier>fieldSection4Id</identifier>
             </componentInstance>
         </itemInstances>
         <name>Facet-4f1f8bf5-0b65-42aa-bf9b-83c22460ab0c</name>
@@ -354,8 +398,12 @@
     <flexiPageRegions>
         <itemInstances>
             <fieldInstance>
-                <identifier>createdById1Id</identifier>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
                 <fieldItem>Record.CreatedById</fieldItem>
+                <identifier>createdById1Id</identifier>
                 <visibilityRule>
                     <criteria>
                         <leftValue>{!Record.Name}</leftValue>
@@ -374,8 +422,8 @@
                     <name>uiBehavior</name>
                     <value>readonly</value>
                 </fieldInstanceProperties>
-                <identifier>lastModifiedById1Id</identifier>
                 <fieldItem>Record.LastModifiedById</fieldItem>
+                <identifier>lastModifiedById1Id</identifier>
                 <visibilityRule>
                     <criteria>
                         <leftValue>{!Record.Name}</leftValue>
@@ -394,8 +442,8 @@
                     <name>body</name>
                     <value>Facet-89376b72-c133-4a37-aced-a89e617b3445</value>
                 </componentInstanceProperties>
-                <identifier>column8Id</identifier>
                 <componentName>flexipage:column</componentName>
+                <identifier>column8Id</identifier>
             </componentInstance>
         </itemInstances>
         <itemInstances>
@@ -404,8 +452,8 @@
                     <name>body</name>
                     <value>Facet-a3db6553-976d-4530-892c-e7b356e1c77b</value>
                 </componentInstanceProperties>
-                <identifier>column9Id</identifier>
                 <componentName>flexipage:column</componentName>
+                <identifier>column9Id</identifier>
             </componentInstance>
         </itemInstances>
         <name>Facet-6af03da9-539c-4733-99e9-3916976bbe9d</name>
@@ -422,8 +470,8 @@
                     <name>label</name>
                     <value>System Information</value>
                 </componentInstanceProperties>
-                <identifier>fieldSection5Id</identifier>
                 <componentName>flexipage:fieldSection</componentName>
+                <identifier>fieldSection5Id</identifier>
                 <visibilityRule>
                     <criteria>
                         <leftValue>{!Record.Name}</leftValue>
@@ -450,8 +498,8 @@
                     <name>name</name>
                     <value>accordionSection--tjp9me2d7pa</value>
                 </componentInstanceProperties>
-                <identifier>accordionSection1Id</identifier>
                 <componentName>flexipage:accordionSection</componentName>
+                <identifier>accordionSection1Id</identifier>
             </componentInstance>
         </itemInstances>
         <itemInstances>
@@ -468,8 +516,8 @@
                     <name>name</name>
                     <value>accordionSection1</value>
                 </componentInstanceProperties>
-                <identifier>accordionSection2Id</identifier>
                 <componentName>flexipage:accordionSection</componentName>
+                <identifier>accordionSection2Id</identifier>
             </componentInstance>
         </itemInstances>
         <itemInstances>
@@ -486,8 +534,8 @@
                     <name>name</name>
                     <value>accordionSection2</value>
                 </componentInstanceProperties>
-                <identifier>accordionSection3Id</identifier>
                 <componentName>flexipage:accordionSection</componentName>
+                <identifier>accordionSection3Id</identifier>
             </componentInstance>
         </itemInstances>
         <name>Facet-f3e632ab-51ea-464d-8393-8569d85ab8ef</name>
@@ -504,14 +552,14 @@
                     <name>defaultSectionName</name>
                     <value>accordionSection1</value>
                 </componentInstanceProperties>
-                <identifier>accordion1Id</identifier>
                 <componentName>flexipage:accordion</componentName>
+                <identifier>accordion1Id</identifier>
             </componentInstance>
         </itemInstances>
         <itemInstances>
             <componentInstance>
-                <identifier>recordDetailPanelMobile1Id</identifier>
                 <componentName>force:recordDetailPanelMobile</componentName>
+                <identifier>recordDetailPanelMobile1Id</identifier>
             </componentInstance>
         </itemInstances>
         <mode>Replace</mode>
@@ -533,8 +581,8 @@
                     <name>showActionBar</name>
                     <value>true</value>
                 </componentInstanceProperties>
-                <identifier>relatedListContainer1Id</identifier>
                 <componentName>force:relatedListContainer</componentName>
+                <identifier>relatedListContainer1Id</identifier>
             </componentInstance>
         </itemInstances>
         <mode>Replace</mode>
@@ -556,8 +604,8 @@
                     <name>title</name>
                     <value>Standard.Tab.detail</value>
                 </componentInstanceProperties>
-                <identifier>tab1Id</identifier>
                 <componentName>flexipage:tab</componentName>
+                <identifier>tab1Id</identifier>
             </componentInstance>
         </itemInstances>
         <itemInstances>
@@ -570,8 +618,8 @@
                     <name>title</name>
                     <value>Standard.Tab.relatedLists</value>
                 </componentInstanceProperties>
-                <identifier>tab2Id</identifier>
                 <componentName>flexipage:tab</componentName>
+                <identifier>tab2Id</identifier>
             </componentInstance>
         </itemInstances>
         <mode>Replace</mode>
@@ -585,8 +633,8 @@
                     <name>tabs</name>
                     <value>maintabs</value>
                 </componentInstanceProperties>
-                <identifier>tabset2Id</identifier>
                 <componentName>flexipage:tabset</componentName>
+                <identifier>tabset2Id</identifier>
             </componentInstance>
         </itemInstances>
         <mode>Replace</mode>
@@ -596,8 +644,8 @@
     <flexiPageRegions>
         <itemInstances>
             <componentInstance>
-                <identifier>recordFeedContainer1Id</identifier>
                 <componentName>forceChatter:recordFeedContainer</componentName>
+                <identifier>recordFeedContainer1Id</identifier>
             </componentInstance>
         </itemInstances>
         <mode>Replace</mode>

--- a/src/sfdc/base/main/default/flexipages/B2C_Client_ID_Integration_History_Record_Page.flexipage-meta.xml
+++ b/src/sfdc/base/main/default/flexipages/B2C_Client_ID_Integration_History_Record_Page.flexipage-meta.xml
@@ -34,8 +34,8 @@
                     <name>numVisibleActions</name>
                     <value>3</value>
                 </componentInstanceProperties>
-                <identifier>highlightsPanel1Id</identifier>
                 <componentName>force:highlightsPanel</componentName>
+                <identifier>highlightsPanel1Id</identifier>
             </componentInstance>
         </itemInstances>
         <name>header</name>
@@ -48,8 +48,8 @@
                     <name>uiBehavior</name>
                     <value>required</value>
                 </fieldInstanceProperties>
-                <identifier>b2cClientId1Id</identifier>
                 <fieldItem>Record.B2C_Client_ID__c</fieldItem>
+                <identifier>b2cClientId1Id</identifier>
             </fieldInstance>
         </itemInstances>
         <itemInstances>
@@ -58,8 +58,8 @@
                     <name>uiBehavior</name>
                     <value>none</value>
                 </fieldInstanceProperties>
-                <identifier>hasError1Id</identifier>
                 <fieldItem>Record.Has_Error__c</fieldItem>
+                <identifier>hasError1Id</identifier>
             </fieldInstance>
         </itemInstances>
         <name>Facet-7dc4fc91-dbe9-47e5-8b8c-f37512027941</name>
@@ -72,8 +72,8 @@
                     <name>uiBehavior</name>
                     <value>none</value>
                 </fieldInstanceProperties>
-                <identifier>hasToken1Id</identifier>
                 <fieldItem>Record.Has_Token__c</fieldItem>
+                <identifier>hasToken1Id</identifier>
             </fieldInstance>
         </itemInstances>
         <itemInstances>
@@ -82,8 +82,8 @@
                     <name>uiBehavior</name>
                     <value>none</value>
                 </fieldInstanceProperties>
-                <identifier>b2cAuthToken1Id</identifier>
                 <fieldItem>Record.B2C_AuthToken__c</fieldItem>
+                <identifier>b2cAuthToken1Id</identifier>
             </fieldInstance>
         </itemInstances>
         <name>Facet-9050c72c-a664-448c-aa65-4d9945e6ebfc</name>
@@ -96,8 +96,8 @@
                     <name>body</name>
                     <value>Facet-7dc4fc91-dbe9-47e5-8b8c-f37512027941</value>
                 </componentInstanceProperties>
-                <identifier>column5Id</identifier>
                 <componentName>flexipage:column</componentName>
+                <identifier>column5Id</identifier>
             </componentInstance>
         </itemInstances>
         <itemInstances>
@@ -106,8 +106,8 @@
                     <name>body</name>
                     <value>Facet-9050c72c-a664-448c-aa65-4d9945e6ebfc</value>
                 </componentInstanceProperties>
-                <identifier>column6Id</identifier>
                 <componentName>flexipage:column</componentName>
+                <identifier>column6Id</identifier>
             </componentInstance>
         </itemInstances>
         <name>Facet-8c0d82cb-8e82-4b95-a4e8-e7043d1c63f5</name>
@@ -120,8 +120,8 @@
                     <name>uiBehavior</name>
                     <value>required</value>
                 </fieldInstanceProperties>
-                <identifier>accountManagerUrl1Id</identifier>
                 <fieldItem>Record.Account_Manager_Url__c</fieldItem>
+                <identifier>accountManagerUrl1Id</identifier>
             </fieldInstance>
         </itemInstances>
         <name>Facet-61a07228-7b3c-4c93-a224-5e7b552f6f6e</name>
@@ -134,8 +134,8 @@
                     <name>body</name>
                     <value>Facet-61a07228-7b3c-4c93-a224-5e7b552f6f6e</value>
                 </componentInstanceProperties>
-                <identifier>column7Id</identifier>
                 <componentName>flexipage:column</componentName>
+                <identifier>column7Id</identifier>
             </componentInstance>
         </itemInstances>
         <name>Facet-91dbde18-4cd5-4aa5-b0a6-7758b4709366</name>
@@ -144,8 +144,8 @@
     <flexiPageRegions>
         <itemInstances>
             <fieldInstance>
-                <identifier>integrationMessage1Id</identifier>
                 <fieldItem>Record.Integration_Message__c</fieldItem>
+                <identifier>integrationMessage1Id</identifier>
             </fieldInstance>
         </itemInstances>
         <itemInstances>
@@ -154,8 +154,8 @@
                     <name>uiBehavior</name>
                     <value>none</value>
                 </fieldInstanceProperties>
-                <identifier>integrationPayload1Id</identifier>
                 <fieldItem>Record.Integration_Payload__c</fieldItem>
+                <identifier>integrationPayload1Id</identifier>
             </fieldInstance>
         </itemInstances>
         <name>Facet-b65f6eb4-d4de-448d-90c1-b04dd845b2ce</name>
@@ -168,8 +168,8 @@
                     <name>uiBehavior</name>
                     <value>none</value>
                 </fieldInstanceProperties>
-                <identifier>statusCode1Id</identifier>
                 <fieldItem>Record.Status_Code__c</fieldItem>
+                <identifier>statusCode1Id</identifier>
             </fieldInstance>
         </itemInstances>
         <itemInstances>
@@ -178,8 +178,8 @@
                     <name>uiBehavior</name>
                     <value>none</value>
                 </fieldInstanceProperties>
-                <identifier>integrationJSON1Id</identifier>
                 <fieldItem>Record.Integration_JSON__c</fieldItem>
+                <identifier>integrationJSON1Id</identifier>
             </fieldInstance>
         </itemInstances>
         <name>Facet-609ae686-3489-4c81-a2d6-479de77f4537</name>
@@ -192,8 +192,8 @@
                     <name>body</name>
                     <value>Facet-b65f6eb4-d4de-448d-90c1-b04dd845b2ce</value>
                 </componentInstanceProperties>
-                <identifier>column1Id</identifier>
                 <componentName>flexipage:column</componentName>
+                <identifier>column1Id</identifier>
             </componentInstance>
         </itemInstances>
         <itemInstances>
@@ -202,8 +202,8 @@
                     <name>body</name>
                     <value>Facet-609ae686-3489-4c81-a2d6-479de77f4537</value>
                 </componentInstanceProperties>
-                <identifier>column2Id</identifier>
                 <componentName>flexipage:column</componentName>
+                <identifier>column2Id</identifier>
             </componentInstance>
         </itemInstances>
         <name>Facet-485e73ea-d40e-4345-b2be-6b474353df98</name>
@@ -220,8 +220,8 @@
                     <name>label</name>
                     <value>B2C Client ID and Auth Token Summary</value>
                 </componentInstanceProperties>
-                <identifier>fieldSection1Id</identifier>
                 <componentName>flexipage:fieldSection</componentName>
+                <identifier>fieldSection1Id</identifier>
             </componentInstance>
         </itemInstances>
         <itemInstances>
@@ -234,8 +234,8 @@
                     <name>label</name>
                     <value>Account Manager Endpoint Url</value>
                 </componentInstanceProperties>
-                <identifier>fieldSection2Id</identifier>
                 <componentName>flexipage:fieldSection</componentName>
+                <identifier>fieldSection2Id</identifier>
             </componentInstance>
         </itemInstances>
         <itemInstances>
@@ -248,8 +248,8 @@
                     <name>label</name>
                     <value>Integration Summary</value>
                 </componentInstanceProperties>
-                <identifier>fieldSection3Id</identifier>
                 <componentName>flexipage:fieldSection</componentName>
+                <identifier>fieldSection3Id</identifier>
             </componentInstance>
         </itemInstances>
         <name>Facet-917b16b0-1f73-4b68-bf0d-86a82b8d9e1c</name>
@@ -262,8 +262,8 @@
                     <name>uiBehavior</name>
                     <value>readonly</value>
                 </fieldInstanceProperties>
-                <identifier>createdById1Id</identifier>
                 <fieldItem>Record.CreatedById</fieldItem>
+                <identifier>createdById1Id</identifier>
             </fieldInstance>
         </itemInstances>
         <name>Facet-a4f7c310-5eba-412e-8dc7-63e185dc3884</name>
@@ -276,8 +276,8 @@
                     <name>uiBehavior</name>
                     <value>readonly</value>
                 </fieldInstanceProperties>
-                <identifier>lastModifiedById1Id</identifier>
                 <fieldItem>Record.LastModifiedById</fieldItem>
+                <identifier>lastModifiedById1Id</identifier>
             </fieldInstance>
         </itemInstances>
         <name>Facet-46691976-e5fa-4460-a380-420621c94e86</name>
@@ -290,8 +290,8 @@
                     <name>body</name>
                     <value>Facet-a4f7c310-5eba-412e-8dc7-63e185dc3884</value>
                 </componentInstanceProperties>
-                <identifier>column3Id</identifier>
                 <componentName>flexipage:column</componentName>
+                <identifier>column3Id</identifier>
             </componentInstance>
         </itemInstances>
         <itemInstances>
@@ -300,8 +300,8 @@
                     <name>body</name>
                     <value>Facet-46691976-e5fa-4460-a380-420621c94e86</value>
                 </componentInstanceProperties>
-                <identifier>column4Id</identifier>
                 <componentName>flexipage:column</componentName>
+                <identifier>column4Id</identifier>
             </componentInstance>
         </itemInstances>
         <name>Facet-13b10711-fb48-4d96-973f-073bcf6739b4</name>
@@ -318,8 +318,8 @@
                     <name>label</name>
                     <value>System Information</value>
                 </componentInstanceProperties>
-                <identifier>fieldSection4Id</identifier>
                 <componentName>flexipage:fieldSection</componentName>
+                <identifier>fieldSection4Id</identifier>
             </componentInstance>
         </itemInstances>
         <name>Facet-12c5e7b8-8a7c-4217-b5e2-927a278264d5</name>
@@ -340,8 +340,8 @@
                     <name>name</name>
                     <value>accordionSection1</value>
                 </componentInstanceProperties>
-                <identifier>accordionSection1Id</identifier>
                 <componentName>flexipage:accordionSection</componentName>
+                <identifier>accordionSection1Id</identifier>
             </componentInstance>
         </itemInstances>
         <itemInstances>
@@ -358,8 +358,8 @@
                     <name>name</name>
                     <value>accordionSection2</value>
                 </componentInstanceProperties>
-                <identifier>accordionSection2Id</identifier>
                 <componentName>flexipage:accordionSection</componentName>
+                <identifier>accordionSection2Id</identifier>
             </componentInstance>
         </itemInstances>
         <name>Facet-dac0a569-d439-4185-9f38-a0300d8f5571</name>
@@ -376,14 +376,14 @@
                     <name>defaultSectionName</name>
                     <value>accordionSection1</value>
                 </componentInstanceProperties>
-                <identifier>accordion1Id</identifier>
                 <componentName>flexipage:accordion</componentName>
+                <identifier>accordion1Id</identifier>
             </componentInstance>
         </itemInstances>
         <itemInstances>
             <componentInstance>
-                <identifier>recordDetailPanelMobile1Id</identifier>
                 <componentName>force:recordDetailPanelMobile</componentName>
+                <identifier>recordDetailPanelMobile1Id</identifier>
             </componentInstance>
         </itemInstances>
         <name>main</name>
@@ -392,8 +392,8 @@
     <flexiPageRegions>
         <itemInstances>
             <componentInstance>
-                <identifier>recordFeedContainer1Id</identifier>
                 <componentName>forceChatter:recordFeedContainer</componentName>
+                <identifier>recordFeedContainer1Id</identifier>
             </componentInstance>
         </itemInstances>
         <name>sidebar</name>

--- a/src/sfdc/base/main/default/flows/B2CCommerce_B2CClientID_B2CAuthTokenGet.flow-meta.xml
+++ b/src/sfdc/base/main/default/flows/B2CCommerce_B2CClientID_B2CAuthTokenGet.flow-meta.xml
@@ -81,7 +81,7 @@
             <assignToReference>B2CAuthToken</assignToReference>
             <operator>Assign</operator>
             <value>
-                <elementReference>recGet_ValidAuthToken.Name</elementReference>
+                <elementReference>recGet_ValidAuthToken.B2C_AuthToken__c</elementReference>
             </value>
         </assignmentItems>
         <assignmentItems>

--- a/src/sfdc/base/main/default/layouts/B2C_AuthToken__c-B2C AuthToken Layout.layout-meta.xml
+++ b/src/sfdc/base/main/default/layouts/B2C_AuthToken__c-B2C AuthToken Layout.layout-meta.xml
@@ -8,7 +8,7 @@
         <label>Information</label>
         <layoutColumns>
             <layoutItems>
-                <behavior>Required</behavior>
+                <behavior>Readonly</behavior>
                 <field>Name</field>
             </layoutItems>
             <layoutItems>

--- a/src/sfdc/base/main/default/objects/B2C_AuthToken__c/B2C_AuthToken__c.object-meta.xml
+++ b/src/sfdc/base/main/default/objects/B2C_AuthToken__c/B2C_AuthToken__c.object-meta.xml
@@ -162,10 +162,10 @@
     <externalSharingModel>ControlledByParent</externalSharingModel>
     <label>B2C AuthToken</label>
     <nameField>
-        <label>B2C AuthToken</label>
-        <trackFeedHistory>true</trackFeedHistory>
-        <trackHistory>false</trackHistory>
-        <type>Text</type>
+        <displayFormat>B2CAT-{0000}</displayFormat>
+        <label>B2C Auth Token</label>
+        <trackFeedHistory>false</trackFeedHistory>
+        <type>AutoNumber</type>
     </nameField>
     <pluralLabel>B2C AuthTokens</pluralLabel>
     <searchLayouts>

--- a/src/sfdc/base/main/default/objects/B2C_AuthToken__c/fields/B2C_AuthToken__c.field-meta.xml
+++ b/src/sfdc/base/main/default/objects/B2C_AuthToken__c/fields/B2C_AuthToken__c.field-meta.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
-    <fullName>Auth_Token_Value__c</fullName>
+    <fullName>B2C_AuthToken__c</fullName>
     <description>... represents the recorded B2C Commerce Account Manager AuthToken for a given authentication request.</description>
     <externalId>false</externalId>
     <inlineHelpText>... represents the recorded B2C Commerce Account Manager AuthToken for a given authentication request.</inlineHelpText>
-    <label>Auth Token Value</label>
+    <label>B2C AuthToken</label>
     <length>131072</length>
     <trackFeedHistory>false</trackFeedHistory>
+    <trackHistory>false</trackHistory>
     <trackTrending>false</trackTrending>
     <type>LongTextArea</type>
     <visibleLines>4</visibleLines>

--- a/src/sfdc/base/main/default/permissionsets/B2C_CRM_JWT.permissionset-meta.xml
+++ b/src/sfdc/base/main/default/permissionsets/B2C_CRM_JWT.permissionset-meta.xml
@@ -170,6 +170,11 @@
     </customMetadataTypeAccesses>
     <description>... provides access to the b2c-crm-jwt configuration meta-data and page layouts.</description>
     <fieldPermissions>
+        <editable>true</editable>
+        <field>B2C_AuthToken__c.B2C_AuthToken__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
         <editable>false</editable>
         <field>B2C_AuthToken__c.B2C_ClientID_Value__c</field>
         <readable>true</readable>

--- a/src/sfdc/base/main/default/permissionsets/B2C_CRM_SYNC.permissionset-meta.xml
+++ b/src/sfdc/base/main/default/permissionsets/B2C_CRM_SYNC.permissionset-meta.xml
@@ -366,6 +366,11 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
+        <editable>true</editable>
+        <field>B2C_AuthToken__c.B2C_AuthToken__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
         <editable>false</editable>
         <field>B2C_AuthToken__c.B2C_ClientID_Value__c</field>
         <readable>true</readable>

--- a/src/sfdc/extras/sf-connect/base/main/default/classes/B2CDataSourceAddressBookConnection_Test.cls
+++ b/src/sfdc/extras/sf-connect/base/main/default/classes/B2CDataSourceAddressBookConnection_Test.cls
@@ -17,7 +17,7 @@ public with sharing class B2CDataSourceAddressBookConnection_Test {
         });
 
         B2C_AuthToken__c authToken = (B2C_AuthToken__c)TestDataFactory.createSObject('B2C_AuthToken__c', new Map<String,Object>{
-            'Name' => 'my-test-authtoken',
+            'B2C_AuthToken__c' => 'my-test-authtoken',
             'B2C_Client_ID__c' => clientId.Id
         });
         B2C_CustomerList__c customerList = (B2C_CustomerList__c)TestDataFactory.createSObject('B2C_CustomerList__c', new Map<String,Object>{

--- a/src/sfdc/extras/sf-connect/base/main/default/permissionsets/B2C_CRM_JWT.permissionset-meta.xml
+++ b/src/sfdc/extras/sf-connect/base/main/default/permissionsets/B2C_CRM_JWT.permissionset-meta.xml
@@ -190,6 +190,11 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
+        <editable>true</editable>
+        <field>B2C_AuthToken__c.B2C_AuthToken__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
         <editable>false</editable>
         <field>B2C_AuthToken__c.B2C_ClientID_Value__c</field>
         <readable>true</readable>

--- a/src/sfdc/extras/sf-connect/base/main/default/permissionsets/B2C_CRM_SYNC.permissionset-meta.xml
+++ b/src/sfdc/extras/sf-connect/base/main/default/permissionsets/B2C_CRM_SYNC.permissionset-meta.xml
@@ -366,6 +366,11 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
+        <editable>true</editable>
+        <field>B2C_AuthToken__c.B2C_AuthToken__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
         <editable>false</editable>
         <field>B2C_AuthToken__c.B2C_ClientID_Value__c</field>
         <readable>true</readable>

--- a/src/sfdc/extras/sf-connect/personaccounts/main/default/permissionsets/B2C_CRM_SYNC.permissionset-meta.xml
+++ b/src/sfdc/extras/sf-connect/personaccounts/main/default/permissionsets/B2C_CRM_SYNC.permissionset-meta.xml
@@ -371,6 +371,11 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
+        <editable>true</editable>
+        <field>B2C_AuthToken__c.B2C_AuthToken__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
         <editable>false</editable>
         <field>B2C_AuthToken__c.B2C_ClientID_Value__c</field>
         <readable>true</readable>


### PR DESCRIPTION
In order to prepare the b2c-crm-sync framework to the UUID token type depreciation, this PR aims to migrate how b2c-crm-sync authenticates with the B2C Commerce Account Manager, by moving from UUID usage to JWT.
Now the auth token is stored in a custom field on the `B2C_Auth_Token__c` custom object as it cannot live in the Name standard field anymore due to its length.

![Screenshot 2022-10-06 at 12 50 42 PM](https://user-images.githubusercontent.com/47380544/194295033-a8a5a2e5-0532-42e2-9b2a-207362807616.png)
