### PR TITLE
Allow dots in code version

### DIFF
--- a/lib/cli-api/validators/constraints/B2CCodeVersion.js
+++ b/lib/cli-api/validators/constraints/B2CCodeVersion.js
@@ -23,11 +23,11 @@ module.exports = {
             }
         },
         format: {
-            pattern: '^[a-z][a-z0-9_]+',
+            pattern: '^[a-z][a-z0-9_\.]+',
             flags: 'i',
             message: function () {
                 return validate.format(
-                    '^%{attr} must start with a letter -- and only contain letters, numbers, and underscores',
+                    '^%{attr} must start with a letter -- and only contain letters, numbers, dots and underscores',
                     config.get('validatejs.attributePlaceholder'));
             }
         }


### PR DESCRIPTION
Code version often times use dots to separate the version segments in semantic versioning. That's why also dots need to be supported when validating the code version via `npm run crm-sync:b2c:verify`. Validation pattern has been adjusted to cater for it.