### PR TITLE
b2ccrm_syncResponseText related size limit and unit tests

### DIFF
--- a/src/sfcc/cartridges/int_b2ccrmsync/cartridge/scripts/b2ccrmsync/models/customer.js
+++ b/src/sfcc/cartridges/int_b2ccrmsync/cartridge/scripts/b2ccrmsync/models/customer.js
@@ -113,9 +113,9 @@ Customer.prototype = {
     /**
      * @memberOf Customer
      * @function updateSyncResponseText
-     * @description Update the {custom.b2ccrm_syncResponseText} attribute with the given {text}
+     * @description Update the {custom.b2ccrm_syncResponseText} attribute with the given {text}. The text value should never grow bigger than 50,000 characters
      *
-     * @param {String} text The text to save within the sync-response-text set-of-string on the profile
+     * @param {String} text The text to save within the sync-response-text json text on the profile
      */
     updateSyncResponseText: function (text) {
         if (!this.profile) {
@@ -126,6 +126,11 @@ Customer.prototype = {
             var syncResponseText = require('*/cartridge/scripts/b2ccrmsync/util/helpers').expandJSON(this.profile.custom.b2ccrm_syncResponseText, []);
             var thisDate = new Date();
             syncResponseText.unshift(require('dw/util/StringUtils').format('{0}: {1}', thisDate.toUTCString(), text));
+            var responseHistory = JSON.stringify(syncResponseText, null, 2);
+            while (responseHistory.length > 50000) {
+                syncResponseText.pop();
+                responseHistory = JSON.stringify(syncResponseText, null, 2);
+            }
             this.profile.custom.b2ccrm_syncResponseText = JSON.stringify(syncResponseText, null, 2);
         }.bind(this));
 

--- a/test/b2c/int_b2ccrmsync/scripts/models/customer.test.js
+++ b/test/b2c/int_b2ccrmsync/scripts/models/customer.test.js
@@ -217,44 +217,46 @@ describe('int_b2ccrmsync/cartridge/scripts/b2ccrmsync/models/customer', function
             profile.custom.b2ccrm_syncResponseText = undefined;
             const customer = new CustomerModel(profile);
             customer.updateSyncResponseText('response text');
+            const b2ccrm_syncResponseText = JSON.parse(customer.profile.custom.b2ccrm_syncResponseText);
 
             expect(spy).to.have.been.calledOnce;
-            expect(customer.profile.custom.b2ccrm_syncResponseText.length).to.be.equal(1);
-            expect(customer.profile.custom.b2ccrm_syncResponseText[0]).to.not.be.undefined;
+            expect(b2ccrm_syncResponseText.length).to.be.equal(1);
+            expect(b2ccrm_syncResponseText[0]).to.not.be.undefined;
         });
 
         it('should save response text in the profile custom attribute if this is the first time the response text is saved', function () {
             spy = sinon.spy(require('dw-api-mock/dw/system/Transaction'), 'wrap');
             const customer = new CustomerModel(profile);
             customer.updateSyncResponseText('response text');
+            const b2ccrm_syncResponseText = JSON.parse(customer.profile.custom.b2ccrm_syncResponseText);
 
             expect(spy).to.have.been.calledOnce;
-            expect(customer.profile.custom.b2ccrm_syncResponseText.length).to.be.equal(1);
-            expect(customer.profile.custom.b2ccrm_syncResponseText[0]).to.not.be.undefined;
+            expect(b2ccrm_syncResponseText.length).to.be.equal(1);
+            expect(b2ccrm_syncResponseText[0]).to.not.be.undefined;
         });
 
         it('should save response text in the profile custom attribute, even if we already saved response texts previously', function () {
             spy = sinon.spy(require('dw-api-mock/dw/system/Transaction'), 'wrap');
-            profile.custom.b2ccrm_syncResponseText = ['previously saved response text'];
+            profile.custom.b2ccrm_syncResponseText = JSON.stringify(['previously saved response text']);
             const customer = new CustomerModel(profile);
             customer.updateSyncResponseText('response text');
+            const b2ccrm_syncResponseText = JSON.parse(customer.profile.custom.b2ccrm_syncResponseText);
 
             expect(spy).to.have.been.calledOnce;
-            expect(customer.profile.custom.b2ccrm_syncResponseText.length).to.be.equal(2);
-            customer.profile.custom.b2ccrm_syncResponseText.forEach(value => expect(value).to.not.be.undefined);
+            expect(b2ccrm_syncResponseText.length).to.be.equal(2);
+            b2ccrm_syncResponseText.forEach(value => expect(value).to.not.be.undefined);
         });
 
-        it('should save response text in the profile custom attribute, and remove the first element of the array as the limit is reached', function () {
+        it('should save response text in the profile custom attribute, and make sure the response does never get bigger than 50,000 characters', function () {
             spy = sinon.spy(require('dw-api-mock/dw/system/Transaction'), 'wrap');
             const customer = new CustomerModel(profile);
-            for (let i = 0; i < 201; ++i) {
+            for (let i = 0; i < 1001; ++i) {
                 customer.updateSyncResponseText(`response text ${i}`);
             }
 
             expect(spy).to.have.been.called;
             // Ensure the array size is under the limit of 200
-            expect(customer.profile.custom.b2ccrm_syncResponseText.length).to.be.equal(199);
-            customer.profile.custom.b2ccrm_syncResponseText.forEach(value => expect(value).to.not.be.undefined);
+            expect(customer.profile.custom.b2ccrm_syncResponseText.length).to.be.below(50000);
         });
 
         it('should not do anything in case no profile is sent within the model', function () {


### PR DESCRIPTION
b2ccrm_syncResponseText has been transformed into a 'json' text data type. The limit of 100,000 characters applies but has not been catered for. This fix addresses both the failing unit tests and the limitation to 50,0000 characters for this data field.